### PR TITLE
Expose ArgoCD's `ignoreDifferences` as a component parameter

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,5 +1,6 @@
 parameters:
   adhoc_configurations:
+    argocd_ignore_differences: {}
     manifests_path: manifests/${cluster:name}
     resourcelocker:
       serviceaccount:

--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -5,7 +5,20 @@ local argocd = import 'lib/argocd.libjsonnet';
 
 // We target the App at the default namespace with the understanding that
 // manifests should always be be namespaced
-local app = argocd.App('adhoc-configurations', 'default');
+local app = argocd.App('adhoc-configurations', 'default') {
+  spec+: {
+    ignoreDifferences:
+      // This completely ignores the keys in the parameter, since we only use
+      // a dictionary over a list to allow users to edit existing entries in
+      // the hierarchy.
+      // We also allow users to disable already configured diff customizations
+      // by setting the corresponding entry's value to `null`.
+      std.filter(
+        function(it) it != null,
+        std.objectValues(params.argocd_ignore_differences)
+      ),
+  },
+};
 
 {
   'adhoc-configurations': app,

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -2,6 +2,18 @@
 
 The parent key for all of the following parameters is `adhoc_configurations`.
 
+== `argocd_ignore_differences`
+
+[horizontal]
+type:: object
+default:: `{}`
+
+This parameter allows users to configure ArgoCD to ignore certain differences for resources managed by the component.
+
+The component ignores the object keys, and uses the non-null values as entries for `.spec.ignoreDifferences` of the ArgoCD application resource.
+
+See the [ArgoCD documentation]https://argo-cd.readthedocs.io/en/stable/user-guide/diffing/#application-level-configuration for all available features of ArgoCD's diffing customization.
+
 == `manifests_path`
 
 [horizontal]


### PR DESCRIPTION
We allow users to configure ArgoCD's diffing customization through the hierarchy in parameter `argocd_ignore_differences`. This is helpful when deploying some resource which is mutated by an admission webhook through the adhoc-configurations component.

The new parameter is an object, to allow users to modify or remove existing configurations in the hierarchy. However, the component completely ignores the object keys, and uses only the non-null values to create the list for `spec.ignoreDifferences` in the ArgoCD application resource.

Closes #25




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
