### PR TITLE
Add support for processing `Patch` resources in subdirectories of the manifests path

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,6 +2,7 @@ parameters:
   adhoc_configurations:
     argocd_ignore_differences: {}
     manifests_path: manifests/${cluster:name}
+    patch_subdirectories: []
     patches:
       serviceaccount:
         create: true

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -24,6 +24,12 @@ Base directory in which the ad-hoc manifests are saved in the tenant repo.
 
 The component will copy any files saved at the path indicated by `manifests_path` in the tenant repo to the cluster catalog.
 
+== `patch_subdirectories`
+type:: list
+default:: `[]`
+
+A list of subdirectories of `manifests_path` in which the component should search for `Patch` resources.
+This allows users to store partial `Patch` resources in a subdirectory of `manifests_path` without having to manage the patch-operator RBAC themselves.
 
 == `patches`
 

--- a/inventory/classes/t-silent-test-1234/c-green-test-1234/foo/patch.yaml
+++ b/inventory/classes/t-silent-test-1234/c-green-test-1234/foo/patch.yaml
@@ -1,0 +1,5 @@
+kind: Patch
+metadata:
+  name: test-patch-subdir
+spec:
+  patches: {}

--- a/postprocess/patch_operator.jsonnet
+++ b/postprocess/patch_operator.jsonnet
@@ -116,10 +116,23 @@ local stem(elem) =
   local elems = std.split(elem, '.');
   std.join('.', elems[:std.length(elems) - 1]);
 
+local files =
+  com.list_dir(manifests_dir) +
+  std.flattenArrays(
+    [
+      std.map(
+        function(elem) subdir + '/' + elem,
+        com.list_dir(manifests_dir + '/' + subdir)
+      )
+      for subdir in params.patch_subdirectories
+    ]
+  );
+
+
 local output = {
   local input_file(elem) = manifests_dir + '/' + elem,
-  [stem(elem)]: fixup(input_file(elem))
-  for elem in com.list_dir(manifests_dir)
+  [stem(file)]: fixup(input_file(file))
+  for file in files
 };
 
 {

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -13,3 +13,5 @@ parameters:
 
   adhoc_configurations:
     manifests_path: ${cluster:name}
+    patch_subdirectories:
+      - foo

--- a/tests/golden/defaults/adhoc-configurations/adhoc-configurations/foo/patch.yaml
+++ b/tests/golden/defaults/adhoc-configurations/adhoc-configurations/foo/patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: Patch
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: adhoc-configurations-test-patch-subdir
+  namespace: syn-patch-operator
+spec:
+  patches: {}
+  serviceAccountRef:
+    name: adhoc-configurations-manager


### PR DESCRIPTION
Until now, the `Patch` resource postprocessing filter only worked for `Patch` resources defined in top-level YAML files in the manifests path.

This commit introduces a new component parameter `patch_subdirectories` through which users can specify subdirectories in the manifests path in which the postprocessing filter should search for `Patch` resources.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
